### PR TITLE
Add PDF type detection and element routing framework

### DIFF
--- a/src/digital_element_classifier.py
+++ b/src/digital_element_classifier.py
@@ -1,0 +1,40 @@
+"""Identification utilities for elements within digitally generated PDFs.
+
+The functions in this module categorise high-level page elements such as
+text blocks, tables and images. No processing of the extracted content is
+performed here; downstream modules should handle each element type
+separately.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+import pdfplumber
+
+ElementType = Dict[str, List]
+
+
+@dataclass
+class DigitalElementClassifier:
+    """Locate simple elements on each page of a digital PDF."""
+
+    def classify(self, pdf_path: str) -> List[ElementType]:
+        """Return a list with one entry per page describing element types.
+
+        Each entry contains the keys ``text``, ``tables`` and ``images`` with
+        metadata describing the location of each element. The goal is merely to
+        identify their presence; detailed processing is delegated elsewhere.
+        """
+        results: List[ElementType] = []
+
+        with pdfplumber.open(pdf_path) as pdf:
+            for page in pdf.pages:
+                page_data: ElementType = {
+                    "text": page.extract_words(),
+                    "tables": [table.bbox for table in page.find_tables()],
+                    "images": page.images,
+                }
+                results.append(page_data)
+
+        return results

--- a/src/element_router.py
+++ b/src/element_router.py
@@ -1,0 +1,30 @@
+"""Route identified PDF elements to their respective processors.
+
+This module demonstrates how different element types can be dispatched to
+separate processing modules. The processors themselves currently contain
+placeholders and will be implemented in later iterations.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+from . import image_processor, table_processor, text_processor
+
+
+def route_elements(pages: Iterable[dict]) -> None:
+    """Dispatch elements from ``DigitalElementClassifier`` results.
+
+    Parameters
+    ----------
+    pages:
+        An iterable of dictionaries as returned by
+        :class:`DigitalElementClassifier`, where each dictionary contains
+        ``text``, ``tables`` and ``images`` keys.
+    """
+    for page in pages:
+        if page["text"]:
+            text_processor.process_text(page["text"])
+        for table in page["tables"]:
+            table_processor.process_table(table)
+        for image in page["images"]:
+            image_processor.process_image(image)

--- a/src/image_processor.py
+++ b/src/image_processor.py
@@ -1,0 +1,11 @@
+"""Placeholder for image processing logic."""
+
+from __future__ import annotations
+
+
+def process_image(image_data):
+    """Process image data from a PDF.
+
+    Actual implementation will be added later.
+    """
+    raise NotImplementedError("Image processing is not implemented yet")

--- a/src/pdf_type_detector.py
+++ b/src/pdf_type_detector.py
@@ -1,0 +1,38 @@
+"""Utilities for determining whether a PDF file is digitally generated or scanned.
+
+This module only detects the type of PDF. It does not attempt to perform
+any OCR or further extraction. The simple heuristic used here checks
+whether any text can be extracted from the first page of the document.
+If text is present, the PDF is assumed to be digital; otherwise it is
+likely a scanned document.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from pdfminer.high_level import extract_text
+
+PdfType = Literal["digital", "scanned"]
+
+
+@dataclass
+class PdfTypeDetector:
+    """Detect whether a PDF is digital or scanned."""
+
+    sample_pages: int = 1
+
+    def detect(self, pdf_path: str) -> PdfType:
+        """Return ``"digital"`` if text is found, otherwise ``"scanned"``.
+
+        The detector only examines a small number of pages (``sample_pages``)
+        for performance reasons. Any error during extraction falls back to a
+        ``"scanned"`` result because scanned PDFs typically lack parseable
+        text streams.
+        """
+        try:
+            text = extract_text(pdf_path, maxpages=self.sample_pages)
+        except Exception:
+            return "scanned"
+
+        return "digital" if text and text.strip() else "scanned"

--- a/src/table_processor.py
+++ b/src/table_processor.py
@@ -1,0 +1,11 @@
+"""Placeholder for table processing logic."""
+
+from __future__ import annotations
+
+
+def process_table(table_data):
+    """Process table data from a PDF.
+
+    Actual implementation will be added later.
+    """
+    raise NotImplementedError("Table processing is not implemented yet")

--- a/src/text_processor.py
+++ b/src/text_processor.py
@@ -1,0 +1,11 @@
+"""Placeholder for text processing logic."""
+
+from __future__ import annotations
+
+
+def process_text(text_blocks):
+    """Process text blocks from a PDF.
+
+    Actual implementation will be added later.
+    """
+    raise NotImplementedError("Text processing is not implemented yet")


### PR DESCRIPTION
## Summary
- Add `PdfTypeDetector` to distinguish between digital and scanned PDFs
- Implement `DigitalElementClassifier` to tag text, tables, and images in digital PDFs
- Introduce placeholder processors and router for future element-specific handling

## Testing
- `python -m compileall src`


------
https://chatgpt.com/codex/tasks/task_e_68acb67b50cc83229a6ba8bdc375d4a8