### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pdfminer.six pdfplumber pytest
+      - name: Run tests
+        run: pytest

--- a/data/digital.pdf
+++ b/data/digital.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 42 >>
+stream
+BT /F1 24 Tf 72 120 Td (Hello World) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000333 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+403
+%%EOF

--- a/data/scanned.pdf
+++ b/data/scanned.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 0 >>
+stream
+
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000290 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+360
+%%EOF

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))

--- a/tests/test_digital_element_classifier.py
+++ b/tests/test_digital_element_classifier.py
@@ -1,0 +1,13 @@
+from digital_element_classifier import DigitalElementClassifier
+
+
+def test_classify_detects_text():
+    classifier = DigitalElementClassifier()
+    result = classifier.classify('data/digital.pdf')
+    assert isinstance(result, list)
+    assert len(result) == 1
+    page = result[0]
+    assert 'text' in page and 'tables' in page and 'images' in page
+    assert page['text']  # should contain words
+    assert page['tables'] == []
+    assert page['images'] == []

--- a/tests/test_element_router.py
+++ b/tests/test_element_router.py
@@ -1,0 +1,27 @@
+from digital_element_classifier import DigitalElementClassifier
+from element_router import route_elements
+
+
+def test_route_elements_dispatches(monkeypatch):
+    calls = {"text": 0, "table": 0, "image": 0}
+
+    def fake_text(blocks):
+        calls["text"] += 1
+
+    def fake_table(table):
+        calls["table"] += 1
+
+    def fake_image(image):
+        calls["image"] += 1
+
+    monkeypatch.setattr("element_router.text_processor.process_text", fake_text)
+    monkeypatch.setattr("element_router.table_processor.process_table", fake_table)
+    monkeypatch.setattr("element_router.image_processor.process_image", fake_image)
+
+    classifier = DigitalElementClassifier()
+    pages = classifier.classify('data/digital.pdf')
+    route_elements(pages)
+
+    assert calls["text"] == 1
+    assert calls["table"] == 0
+    assert calls["image"] == 0

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -1,0 +1,7 @@
+import pytest
+from image_processor import process_image
+
+
+def test_process_image_not_implemented():
+    with pytest.raises(NotImplementedError):
+        process_image(None)

--- a/tests/test_pdf_type_detector.py
+++ b/tests/test_pdf_type_detector.py
@@ -1,0 +1,11 @@
+from pdf_type_detector import PdfTypeDetector
+
+
+def test_detect_digital_pdf():
+    detector = PdfTypeDetector()
+    assert detector.detect('data/digital.pdf') == 'digital'
+
+
+def test_detect_scanned_pdf():
+    detector = PdfTypeDetector()
+    assert detector.detect('data/scanned.pdf') == 'scanned'

--- a/tests/test_table_processor.py
+++ b/tests/test_table_processor.py
@@ -1,0 +1,7 @@
+import pytest
+from table_processor import process_table
+
+
+def test_process_table_not_implemented():
+    with pytest.raises(NotImplementedError):
+        process_table(None)

--- a/tests/test_text_processor.py
+++ b/tests/test_text_processor.py
@@ -1,0 +1,7 @@
+import pytest
+from text_processor import process_text
+
+
+def test_process_text_not_implemented():
+    with pytest.raises(NotImplementedError):
+        process_text([])


### PR DESCRIPTION
## Summary
- add minimal digital and scanned PDF fixtures
- introduce tests for element classification, PDF type detection, and placeholder processors
- configure GitHub Actions to run pytest

## Testing
- `pytest` *(fails: No module named 'pdfplumber', No module named 'pdfminer')*


------
https://chatgpt.com/codex/tasks/task_e_68acb98f6d608322aa6d29fe633e776e