### PR TITLE
Add package init with high-level convenience APIs

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,17 @@
+"""Top-level package for PDF data extraction utilities.
+
+Provides convenience functions for common operations."""
+
+from .digital_element_classifier import DigitalElementClassifier
+from .element_router import route_elements
+
+
+def classify(pdf_path: str):
+    """Classify elements in a digital PDF.
+
+    This is a convenience wrapper around :class:`DigitalElementClassifier`.
+    """
+    return DigitalElementClassifier().classify(pdf_path)
+
+
+__all__ = ["classify", "route_elements", "DigitalElementClassifier"]


### PR DESCRIPTION
## Summary
- add `src/__init__.py` to make the src directory a package
- expose `classify` and `route_elements` for easier top-level imports

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acba3727888322955830acb35dfe70