### PR TITLE
Add notebook demonstrating PDF processing pipeline

### DIFF
--- a/notebooks/pipeline_demo.ipynb
+++ b/notebooks/pipeline_demo.ipynb
@@ -1,0 +1,88 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PDF Processing Pipeline Demo\n",
+    "\n",
+    "This notebook demonstrates how to detect the type of a PDF, classify elements from digital PDFs, and route those elements to placeholder processors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append('../src')\n",
+    "\n",
+    "from pdf_type_detector import PdfTypeDetector\n",
+    "from digital_element_classifier import DigitalElementClassifier\n",
+    "from element_router import route_elements\n",
+    "from pathlib import Path\n",
+    "\n",
+    "pdf_path = Path('../data/digital.pdf')\n",
+    "\n",
+    "detector = PdfTypeDetector()\n",
+    "pdf_type = detector.detect(str(pdf_path))\n",
+    "pdf_type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if pdf_type == 'digital':\n",
+    "    classifier = DigitalElementClassifier()\n",
+    "    pages = classifier.classify(str(pdf_path))\n",
+    "else:\n",
+    "    pages = []\n",
+    "\n",
+    "pages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Patch processor modules with simple stand-ins so the demo can run end-to-end\n",
+    "import text_processor, table_processor, image_processor\n",
+    "\n",
+    "def show_text(blocks):\n",
+    "    print(f'Text blocks: {len(blocks)}')\n",
+    "\n",
+    "def show_table(table):\n",
+    "    print('Table bbox:', table)\n",
+    "\n",
+    "def show_image(image):\n",
+    "    print('Image:', image)\n",
+    "\n",
+    "text_processor.process_text = show_text\n",
+    "table_processor.process_table = show_table\n",
+    "image_processor.process_image = show_image\n",
+    "\n",
+    "# Route the elements collected in the previous step\n",
+    "route_elements(pages)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add `pipeline_demo.ipynb` notebook to explore PDF type detection, element classification, and routing

## Testing
- `pytest` *(fails: No module named 'pdfplumber')*
- `pip install pdfplumber` *(fails: Could not find a version that satisfies the requirement pdfplumber)*

------
https://chatgpt.com/codex/tasks/task_e_68acbe02ae5883229d8a00aa4bdd8e42