### PR TITLE
Skip already processed documents

### DIFF
--- a/src/extraction/utils/document_manager.py
+++ b/src/extraction/utils/document_manager.py
@@ -249,6 +249,8 @@ class DocumentManager:
     def process_from_unprocessed(self, unprocessed_dir: str = "data/unprocessed_documents") -> List[str]:
         """
         Process all PDFs from the unprocessed documents directory.
+        Documents that already have a corresponding folder in the
+        processed documents directory will be skipped.
         
         Args:
             unprocessed_dir: Path to directory containing unprocessed PDFs
@@ -273,17 +275,22 @@ class DocumentManager:
         print(f"🔍 Found {len(pdf_files)} PDF files to process")
         
         for pdf_file in pdf_files:
-            # Create document ID from filename (remove .pdf extension)
+            # Use the PDF filename (without extension) as the document ID
             pdf_name = Path(pdf_file).stem
-            document_id = f"{pdf_name}_{int(datetime.now().timestamp())}"
-            
+            document_id = pdf_name
+
+            # Skip processing if a document with this ID already exists
+            if self.data_settings.get_document_path(document_id).exists():
+                print(f"⏭️  Skipping already processed document: {document_id}")
+                continue
+
             print(f"\n📋 Processing: {pdf_name}")
             print(f"🆔 Document ID: {document_id}")
-            
+
             # Create document structure and copy PDF
             doc_path = self.create_document(document_id, pdf_file)
             processed_docs.append(document_id)
-            
+
             print(f"✅ Document structure created at: {doc_path}")
         
         return processed_docs

--- a/tests/test_document_manager.py
+++ b/tests/test_document_manager.py
@@ -1,0 +1,52 @@
+import shutil
+from pathlib import Path
+import sys
+
+# Ensure local packages are importable before any external 'config' package
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from config.settings import DataSettings
+from config import settings
+
+# Import DocumentManager without triggering heavy package imports
+import importlib.util
+
+doc_manager_path = Path(__file__).resolve().parents[1] / "src/extraction/utils/document_manager.py"
+spec = importlib.util.spec_from_file_location("document_manager", doc_manager_path)
+document_manager_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(document_manager_module)
+DocumentManager = document_manager_module.DocumentManager
+
+
+def test_process_from_unprocessed_skips_existing(tmp_path, monkeypatch):
+    # Set up temporary directories for data paths
+    data_root = tmp_path / "data"
+    unprocessed_dir = data_root / "unprocessed_documents"
+    documents_dir = data_root / "documents"
+    temp_dir = tmp_path / "temp"
+    unprocessed_dir.mkdir(parents=True)
+    documents_dir.mkdir(parents=True)
+    temp_dir.mkdir(parents=True)
+
+    # Override global data settings to use temporary paths
+    data_settings = DataSettings(
+        data_dir=data_root,
+        documents_dir=documents_dir,
+        temp_dir=temp_dir,
+    )
+    monkeypatch.setattr(settings, "data", data_settings, raising=False)
+
+    # Create a minimal PDF in the unprocessed directory
+    sample_pdf = unprocessed_dir / "sample.pdf"
+    sample_pdf.write_bytes(b"%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF")
+
+    manager = DocumentManager()
+
+    # First pass should process the file
+    processed = manager.process_from_unprocessed(str(unprocessed_dir))
+    assert processed == ["sample"]
+    assert (documents_dir / "sample").exists()
+
+    # Second pass should detect existing folder and skip
+    processed_again = manager.process_from_unprocessed(str(unprocessed_dir))
+    assert processed_again == []


### PR DESCRIPTION
## Summary
- avoid reprocessing PDFs that already have a folder in `data/documents`
- add regression test for batch processing behaviour

## Testing
- `pytest tests/test_document_manager.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pymupdf')*


------
https://chatgpt.com/codex/tasks/task_e_68ae326df434832297bc97d066d11533